### PR TITLE
extension: fix build error on homebrew env

### DIFF
--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -5,10 +5,12 @@ ADD_DEFINITIONS(-DNUGU_CONFIG_FILENAME="nugu-config.json")
 FILE(GLOB_RECURSE sources *.cc)
 
 ADD_EXECUTABLE(${target_app} ${sources})
-TARGET_LINK_LIBRARIES(${target_app} ${COMMON_LDFLAGS} nugu-extension)
 
 IF (TARGET nugu-extension)
-    ADD_DEPENDENCIES(${target_app} nugu-extension)
+	TARGET_LINK_LIBRARIES(${target_app} ${COMMON_LDFLAGS} nugu-extension)
+	ADD_DEPENDENCIES(${target_app} nugu-extension)
+ELSE()
+	TARGET_LINK_LIBRARIES(${target_app} ${pkgs_LDFLAGS})
 ENDIF()
 
 INSTALL(TARGETS ${target_app} DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Fix `TARGET_LINK_LIBRARIES` option to fix build error on Homebrew environment.